### PR TITLE
Add Dimensions.SingleOutput[type]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitgo/unspents",
-  "version": "0.4.3-rc2",
+  "version": "0.4.4-rc1",
   "description": "Defines the chain codes used for different unspent types and methods to calculate bitcoin transaction sizes",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/dimensions.ts
+++ b/src/dimensions.ts
@@ -243,6 +243,14 @@ export interface IDimensionsStruct extends t.Struct<IDimensions> {
   fromUnspents(unspents: Array<{ chain: ChainCode }>): IDimensions;
 
   fromTransaction(tx: IBitcoinTx, params?: { assumeUnsigned?: symbol } ): IDimensions;
+
+  SingleOutput: {
+    p2sh: IDimensions,
+    p2shP2wsh: IDimensions,
+    p2wsh: IDimensions,
+    p2pkh: IDimensions,
+    p2wpkh: IDimensions,
+  }
 }
 
 /**
@@ -624,3 +632,17 @@ Dimensions.prototype.getOutputsVSize = function() {
 Dimensions.prototype.getVSize = function() {
   return this.getOverheadVSize() + this.getInputsVSize() + this.getOutputsVSize();
 };
+
+{
+  const singleOutput = (size: number) =>
+    Object.freeze(Dimensions.sum({ outputs: { count: 1, size }}));
+
+  Dimensions.SingleOutput = {
+    p2sh: singleOutput(VirtualSizes.txP2shOutputSize),
+    p2shP2wsh: singleOutput(VirtualSizes.txP2shP2wshOutputSize),
+    p2wsh: singleOutput(VirtualSizes.txP2wshOutputSize),
+
+    p2pkh: singleOutput(VirtualSizes.txP2pkhOutputSize),
+    p2wpkh: singleOutput(VirtualSizes.txP2wpkhOutputSize),
+  }
+}

--- a/test/dimensions.ts
+++ b/test/dimensions.ts
@@ -69,6 +69,18 @@ describe('Dimensions Arithmetic', function() {
     sum.nOutputs.should.eql(sum.outputs.count);
   });
 
+  it('provides some typical output sizes', function () {
+    ([
+      [Dimensions.SingleOutput.p2sh, VirtualSizes.txP2shOutputSize],
+      [Dimensions.SingleOutput.p2shP2wsh, VirtualSizes.txP2shP2wshOutputSize],
+      [Dimensions.SingleOutput.p2wsh, VirtualSizes.txP2wshOutputSize],
+      [Dimensions.SingleOutput.p2pkh, VirtualSizes.txP2pkhOutputSize],
+      [Dimensions.SingleOutput.p2wpkh, VirtualSizes.txP2wpkhOutputSize]
+    ] as [IDimensions, number][]).forEach(([dims, size]) => {
+      dims.getOutputsVSize().should.eql(size);
+    });
+  });
+
   it('prevents sum of invalid data', function() {
     should.doesNotThrow(() => Dimensions.sum({ outputs: { count: 0, size: 0 } }));
     should.doesNotThrow(() => Dimensions.sum({ outputs: { count: 1, size: 1 } }));


### PR DESCRIPTION
Where type is one of `[p2sh, p2shP2wsh, p2wsh, p2pkh, p2wpkh]`.

This is a shorthand for

```
Dimensions.sum({
  outputs: { count: 1, size: VirtualSizes.txP2shOutputSize }
})
```

Now:

```
Dimensions.SingleOutput.p2sh
```