### PR TITLE
BG-11935: Compile typescript on publish instead of postinstall

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+!dist/
+dist/*.map
+src/
+test/
+.idea/
+git_hooks/
+scripts/
+.eslintrc.json
+CODEOWNERS
+tslint.json
+tsconfig.json
+tsconfig.build.json

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ The package has two components:
 * `Codes`: BitGo-defined chain codes for categorizing unspents.
 * `Dimensions` class with methods to calculate bitcoin transaction sizes
 
+## Installation
+
+```
+npm install --save @bitgo/unspents
+```
 
 ## Chain Codes
 
@@ -80,3 +85,13 @@ Dimensions
   .plus(Dimensions.fromOutputOnChain(Codes.p2shP2wsh.internal).times(nOutputs))
   .getVSize();
 ```
+
+## Publishing new versions
+
+Publishing new versions should be done by running the publish script in `scripts/publish.sh`.
+
+It can be invoked with the name of the branch to release, and will default to the currently checked out branch if not given.
+
+It will perform validation of all prepublish conditions, run a dry-run publish, then, if successful, a real publish. After that is complete,
+the newly installed package will be downloaded and `require()`'d to ensure the package was published correctly.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1763,7 +1763,8 @@
     "typescript": {
       "version": "3.3.4000",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.4000.tgz",
-      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA=="
+      "integrity": "sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==",
+      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
-    "postinstall": "npm run build",
     "test": "mocha --require ts-node/register \"test/**/*.ts\""
   },
   "repository": {
@@ -37,13 +36,13 @@
     "should": "~13.2.3",
     "ts-node": "~8.0.3",
     "tslint": "~5.14.0",
-    "tslint-eslint-rules": "~5.4.0"
+    "tslint-eslint-rules": "~5.4.0",
+    "typescript": "~3.3.4000"
   },
   "dependencies": {
     "@types/lodash": "~4.14.123",
     "@types/node": "~10.14.4",
     "lodash": "~4.17.11",
-    "tcomb": "~3.2.29",
-    "typescript": "~3.3.4000"
+    "tcomb": "~3.2.29"
   }
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Due to the strange behavior in npm@3 of running prepublish scripts during npm install,
+# this script is designed as a replacement for `npm publish` for correctly preparing,
+# building, publishing, and verifying this package.
+
+# this script needs jq installed for json parsing
+command -v jq >/dev/null 2>&1 || error "jq must be installed to run publish"
+
+usage() {
+    echo "usage: $0 [branch-name]"
+    echo
+    echo "Builds, publishes, and verifies a release from the given branch name"
+    echo
+    echo "If branch-name is not given, HEAD is used as the release branch"
+    exit 0
+}
+
+error() {
+    echo "error: $1"
+    exit ${2:-1}
+}
+
+confirm()  {
+    echo -n "$1 [yN]: "
+    read confirm
+    [[ "$confirm" != "y" ]] && [[ "$confirm" != "Y" ]] && error "user aborted"
+}
+
+# check preconditions
+# make sure we can read the package.json
+[[ -f package.json ]] || error "could not locate package.json in directory $(pwd). Publish must be run from the package root."
+git rev-parse --abbrev-ref "${1:-HEAD}" >/dev/null 2>&1 || error "branch $1 does not exist"
+PACKAGE_NAME="$(cat package.json | jq -r '.name')"
+PACKAGE_VERSION="$(cat package.json | jq -r '.version')"
+BRANCH_NAME="$(git rev-parse --abbrev-ref ${1:-HEAD})"
+
+# warn if release is not rel/something
+[[ "$BRANCH_NAME" == "rel/*" ]] || \
+confirm "Branch $BRANCH_NAME does not look like a release branch. Are you sure you want to publish this branch?"
+
+# make sure the working directory is clean
+[[ -z "$(git status --porcelain)" ]] || error "working directory not clean"
+
+# install
+npm install
+
+# build
+npm run build
+echo "executing dry run publish of $PACKAGE_NAME@$PACKAGE_VERSION from branch $BRANCH_NAME..."
+npm publish --dry-run
+confirm "Does everything look ok?"
+
+echo
+echo "publishing package with the following details to npm:"
+echo "package: $PACKAGE_NAME"
+echo "version: $PACKAGE_VERSION"
+echo "branch: $BRANCH_NAME"
+echo "commit: $(git rev-parse HEAD)"
+echo "date: $(date)"
+echo
+confirm "confirm publish"
+
+echo -n "enter OTP: "
+read otp
+npm publish --otp="$otp"
+
+# verify package
+echo "verifying correct publish of $PACKAGE_NAME@$PACKAGE_VERSION"
+cd "$(mktemp -d)"
+npm init -y >/dev/null 2>&1 || error "npm init failed. Verify package manually."
+npm install "$PACKAGE_NAME@$PACKAGE_VERSION" >/dev/null 2>&1 || error "npm install failed! May need to unpublish!!!"
+node -e "require('${PACKAGE_NAME}')" || error "node require failed! unpublish!!!"
+cd $OLDPWD
+echo "correct publish of $PACKAGE_NAME@$PACKAGE_VERSION has been verified!"


### PR DESCRIPTION
* Move typescript to dev deps
* Add publish script for validating prepublish preconditions, publishing, and postpublish smoke testing of the new package from npm.
* Add files which we don't need in the npm package to .npmignore
* Update readme with install and publish instructions